### PR TITLE
WIP: add xvec accessor and coords_to_crs

### DIFF
--- a/xvec/__init__.py
+++ b/xvec/__init__.py
@@ -1,5 +1,6 @@
 from importlib.metadata import PackageNotFoundError, version
 
+from .accessor import XvecAccessor  # noqa
 from .index import GeometryIndex  # noqa
 
 try:

--- a/xvec/accessor.py
+++ b/xvec/accessor.py
@@ -29,7 +29,7 @@ class XvecAccessor:
         crs = CRS.from_user_input(crs)
 
         if data_crs.is_exact_same(crs):
-            return self
+            return self._obj
 
         transformer = Transformer.from_crs(data_crs, crs, always_xy=True)
 

--- a/xvec/accessor.py
+++ b/xvec/accessor.py
@@ -1,0 +1,59 @@
+from typing import Any, Hashable, Union
+
+import numpy as np
+import shapely
+import xarray as xr
+from pyproj import CRS, Transformer
+
+from .index import GeometryIndex
+
+
+@xr.register_dataarray_accessor("xvec")
+@xr.register_dataset_accessor("xvec")
+class XvecAccessor:
+    def __init__(self, xarray_obj: Union[xr.Dataset, xr.DataArray]):
+        self._obj = xarray_obj
+
+    def coords_to_crs(self, coords: Hashable, crs: Any):
+
+        data = self._obj[coords]
+        data_crs = self._obj.xindexes[coords].crs
+
+        # transformation code taken from geopandas (BSD 3-clause license)
+        if data_crs is None:
+            raise ValueError(
+                "Cannot transform naive geometries. "
+                "Please set a CRS on the object first."
+            )
+
+        crs = CRS.from_user_input(crs)
+
+        if data_crs.is_exact_same(crs):
+            return self
+
+        transformer = Transformer.from_crs(data_crs, crs, always_xy=True)
+
+        has_z = shapely.has_z(data)
+
+        result = np.empty_like(data)
+
+        coordinates = shapely.get_coordinates(data[~has_z], include_z=False)
+        new_coords_z = transformer.transform(coordinates[:, 0], coordinates[:, 1])
+        result[~has_z] = shapely.set_coordinates(
+            data[~has_z].copy(), np.array(new_coords_z).T
+        )
+
+        coords_z = shapely.get_coordinates(data[has_z], include_z=True)
+        new_coords_z = transformer.transform(
+            coords_z[:, 0], coords_z[:, 1], coords_z[:, 2]
+        )
+        result[has_z] = shapely.set_coordinates(
+            data[has_z].copy(), np.array(new_coords_z).T
+        )
+
+        # return result
+        return (
+            self._obj.assign_coords({coords: result})
+            .drop_indexes(coords)
+            .set_xindex(coords, GeometryIndex, crs=crs)
+        )


### PR DESCRIPTION
Closes #10 and resolves #5.

This is very much WIP. Implementing `.xvec` accessor and a `coords_to_crs` method, that practically copies the code from GeoPandas. We may consider going through `GeometryArray.to_crs` instead but I'd wait until shapely 2.0 is the only supported engine. Right now, it may cause a bit of trouble and unnecessary conversions.

It currently supports only a single coords. While `drop_indexes` support dropping multiple indexes at the same time, `set_xindex` seems to support only a single one, so we will need a workaround. I think that it may be useful to use a single `coords_to_crs` call to consolidate projections of all geometries instead of going one by one.

To-do:
- [ ] support multiple coords in coords_to_crs
- [ ] check that the index is GeometryIndex
- [ ] tests
- [ ] documentation