### PR TITLE
ENH: add to_geopandas and to_geodataframe

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -41,7 +41,7 @@ jobs:
 
       - name: run tests
         id: status
-        run: pytest -v . -m "not request" --cov=xvec --cov-append --cov-report term-missing --cov-report xml --color=yes --report-log pytest-log.jsonl
+        run: pytest -v . --cov=xvec --cov-append --cov-report term-missing --cov-report xml --color=yes --report-log pytest-log.jsonl
 
       - uses: codecov/codecov-action@v3
 

--- a/ci/dev.yaml
+++ b/ci/dev.yaml
@@ -13,6 +13,7 @@ dependencies:
   - pytest-cov
   - pytest-xdist
   - pytest-reportlog
+  - geopandas-base
   - pip
   - pip:
       - git+https://github.com/shapely/shapely.git@main

--- a/ci/latest.yaml
+++ b/ci/latest.yaml
@@ -13,3 +13,4 @@ dependencies:
   - pytest-cov
   - pytest-xdist
   - pytest-reportlog
+  - geopandas-base

--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -52,6 +52,8 @@ Methods
     Dataset.xvec.set_crs
     Dataset.xvec.to_crs
     Dataset.xvec.query
+    Dataset.xvec.to_geodataframe
+    Dataset.xvec.to_geopandas
 
 
 DataArray.xvec
@@ -84,3 +86,5 @@ Methods
     DataArray.xvec.to_crs
     DataArray.xvec.set_crs
     DataArray.xvec.query
+    DataArray.xvec.to_geodataframe
+    DataArray.xvec.to_geopandas

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -42,6 +42,8 @@ intersphinx_mapping = {
     "shapely": ("https://shapely.readthedocs.io/en/latest/", None),
     "pyproj": ("https://pyproj4.github.io/pyproj/latest/", None),
     "xarray": ("https://docs.xarray.dev/en/latest/", None),
+    "geopandas": ("https://geopandas.org/en/latest", None),
+    "pandas": ("https://pandas.pydata.org/docs", None),
 }
 
 # -- Options for HTML output -------------------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,5 +47,6 @@ omit = ["xvec/tests/*"]
 
 [tool.coverage.report]
 exclude_lines = [
-    "except ImportError"
+    "except ImportError",
+    "except PackageNotFoundError",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,3 +44,8 @@ include = [
 
 [tool.coverage.run]
 omit = ["xvec/tests/*"]
+
+[tool.coverage.report]
+exclude_lines = [
+    "except ImportError"
+]

--- a/xvec/accessor.py
+++ b/xvec/accessor.py
@@ -734,10 +734,17 @@ class XvecAccessor:
                 "'pip install geopandas'."
             )
 
+        if isinstance(self._obj, xr.DataArray) and self._obj.ndim > 2:
+            raise ValueError(
+                f"Cannot convert arrays with {self._obj.ndim} dimensions into pandas "
+                "objects. Requires 2 or fewer dimensions."
+            )
+
         if len(self._geom_indexes) > 1:
             raise ValueError(
-                "Multiple coordinates based on a xvec.GeometryIndex are not supported "
-                "as GeoPandas.GeoDataFrame cannot be indexed by geometry."
+                "Multiple coordinates based on xvec.GeometryIndex are not supported "
+                "as GeoPandas.GeoDataFrame cannot be indexed by geometry. Try using "
+                "`.xvec.to_geodataframe()` instead."
             )
 
         # DataArray
@@ -749,11 +756,6 @@ class XvecAccessor:
                     gdf = self._obj.to_pandas()
                     if gdf.columns.name == self._geom_indexes[0]:
                         gdf = gdf.T
-                else:
-                    raise ValueError(
-                        f"Cannot convert arrays with {self._obj.ndim} dimensions into "
-                        "GeoPandas objects. Requires 1 or 2 dimensions."
-                    )
                 return gdf.reset_index().set_geometry(
                     self._geom_indexes[0],
                     crs=self._obj.xindexes[self._geom_indexes[0]].crs,

--- a/xvec/accessor.py
+++ b/xvec/accessor.py
@@ -785,7 +785,7 @@ class XvecAccessor:
         warnings.warn(
             "No active geometry column to be set. The resulting object "
             "will be a pandas.DataFrame with geopandas.GeometryArray(s) containing "
-            "geometry and CRS information. Use `.set_geometry()` to set an active"
+            "geometry and CRS information. Use `.set_geometry()` to set an active "
             "geometry and upcast to the geopandas.GeoDataFrame manually.",
             UserWarning,
             stacklevel=2,
@@ -880,7 +880,7 @@ class XvecAccessor:
         warnings.warn(
             "No active geometry column to be set. The resulting object "
             "will be a pandas.DataFrame with geopandas.GeometryArray(s) containing "
-            "geometry and CRS information. Use `.set_geometry()` to set an active"
+            "geometry and CRS information. Use `.set_geometry()` to set an active "
             "geometry and upcast to the geopandas.GeoDataFrame manually.",
             UserWarning,
             stacklevel=2,

--- a/xvec/accessor.py
+++ b/xvec/accessor.py
@@ -366,7 +366,8 @@ class XvecAccessor:
         _obj = _obj.drop_indexes(variable_crs.keys())
 
         for key, crs in variable_crs.items():
-            _obj[key].attrs["crs"] = CRS.from_user_input(crs)
+            if crs:
+                _obj[key].attrs["crs"] = CRS.from_user_input(crs)
             _obj = _obj.set_xindex(key, GeometryIndex, crs=crs)
 
         return _obj
@@ -502,7 +503,8 @@ class XvecAccessor:
         _obj = _obj.drop_indexes(variable_crs.keys())
 
         for key, crs in variable_crs.items():
-            _obj[key].attrs["crs"] = CRS.from_user_input(crs)
+            if crs:
+                _obj[key].attrs["crs"] = CRS.from_user_input(crs)
             _obj = _obj.set_xindex(key, GeometryIndex, crs=crs)
 
         return _obj
@@ -692,7 +694,8 @@ class XvecAccessor:
         _obj = _obj.drop_indexes(coord_names)
 
         for coord in coord_names:
-            _obj[coord].attrs["crs"] = CRS.from_user_input(crs)
+            if crs:
+                _obj[coord].attrs["crs"] = CRS.from_user_input(crs)
             _obj = _obj.set_xindex(coord, GeometryIndex, crs=crs, **kwargs)
 
         return _obj

--- a/xvec/tests/conftest.py
+++ b/xvec/tests/conftest.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pandas as pd
 import pytest
 import shapely
 import xarray as xr
@@ -110,3 +111,52 @@ def multi_geom_one_ix_foo(geom_array):
         .drop_indexes(["geom"])
         .set_xindex("geom", GeometryIndex, crs=26915)
     )
+
+
+@pytest.fixture(scope="session")
+def traffic_counts_array(geom_array):
+    return xr.DataArray(
+        np.ones((3, 10, 2, 2, 2)),
+        coords={
+            "mode": ["car", "bike", "walk"],
+            "day": pd.date_range("2023-01-01", periods=10),
+            "hour": range(2),
+            "origin": geom_array,
+            "destination": geom_array,
+        },
+    ).xvec.set_geom_indexes(["origin", "destination"], crs=26915)
+
+
+@pytest.fixture(scope="session")
+def traffic_counts_array_named(traffic_counts_array):
+    traffic_counts_array.name = "traffic_counts"
+    return traffic_counts_array
+
+
+@pytest.fixture(scope="session")
+def traffic_dataset(geom_array):
+    count = np.ones((3, 10, 2, 2, 2))
+    time = np.ones((3, 10, 2, 2, 2))
+
+    return xr.Dataset(
+        {
+            "count": (
+                [
+                    "mode",
+                    "day",
+                    "hour",
+                    "origin",
+                    "destination",
+                ],
+                count,
+            ),
+            "time": (["mode", "day", "hour", "origin", "destination"], time),
+        },
+        coords={
+            "mode": ["car", "bike", "walk"],
+            "origin": geom_array,
+            "destination": geom_array,
+            "hour": range(2),
+            "day": pd.date_range("2023-01-01", periods=10),
+        },
+    ).xvec.set_geom_indexes(["origin", "destination"], crs=26915)

--- a/xvec/tests/conftest.py
+++ b/xvec/tests/conftest.py
@@ -34,6 +34,7 @@ def geom_dataset_no_index(geom_array):
 def geom_dataset(geom_dataset_no_index):
     # a dataset with a geometry coordinate baked by a GeometryIndex
     crs = CRS.from_user_input(26915)
+    geom_dataset_no_index["geom"].attrs["crs"] = crs
     return geom_dataset_no_index.set_xindex("geom", GeometryIndex, crs=crs)
 
 

--- a/xvec/tests/conftest.py
+++ b/xvec/tests/conftest.py
@@ -116,11 +116,10 @@ def multi_geom_one_ix_foo(geom_array):
 @pytest.fixture(scope="session")
 def traffic_counts_array(geom_array):
     return xr.DataArray(
-        np.ones((3, 10, 2, 2, 2)),
+        np.ones((3, 10, 2, 2)),
         coords={
             "mode": ["car", "bike", "walk"],
             "day": pd.date_range("2023-01-01", periods=10),
-            "hour": range(2),
             "origin": geom_array,
             "destination": geom_array,
         },
@@ -135,8 +134,8 @@ def traffic_counts_array_named(traffic_counts_array):
 
 @pytest.fixture(scope="session")
 def traffic_dataset(geom_array):
-    count = np.ones((3, 10, 2, 2, 2))
-    time = np.ones((3, 10, 2, 2, 2))
+    count = np.ones((3, 10, 2, 2))
+    time = np.ones((3, 10, 2, 2))
 
     return xr.Dataset(
         {
@@ -144,19 +143,17 @@ def traffic_dataset(geom_array):
                 [
                     "mode",
                     "day",
-                    "hour",
                     "origin",
                     "destination",
                 ],
                 count,
             ),
-            "time": (["mode", "day", "hour", "origin", "destination"], time),
+            "time": (["mode", "day", "origin", "destination"], time),
         },
         coords={
             "mode": ["car", "bike", "walk"],
             "origin": geom_array,
             "destination": geom_array,
-            "hour": range(2),
             "day": pd.date_range("2023-01-01", periods=10),
         },
     ).xvec.set_geom_indexes(["origin", "destination"], crs=26915)

--- a/xvec/tests/conftest.py
+++ b/xvec/tests/conftest.py
@@ -34,8 +34,9 @@ def geom_dataset_no_index(geom_array):
 def geom_dataset(geom_dataset_no_index):
     # a dataset with a geometry coordinate baked by a GeometryIndex
     crs = CRS.from_user_input(26915)
-    geom_dataset_no_index["geom"].attrs["crs"] = crs
-    return geom_dataset_no_index.set_xindex("geom", GeometryIndex, crs=crs)
+    ds = geom_dataset_no_index.copy()
+    ds["geom"].attrs["crs"] = crs
+    return ds.set_xindex("geom", GeometryIndex, crs=crs)
 
 
 @pytest.fixture(scope="session")
@@ -46,11 +47,13 @@ def geom_dataset_no_crs(geom_dataset_no_index):
 
 @pytest.fixture(scope="session")
 def first_geom_dataset(geom_dataset, geom_array):
-    return (
+    fg = (
         xr.Dataset(coords={"geom": [geom_array[0]]})
         .drop_indexes("geom")
         .set_xindex("geom", GeometryIndex, crs=geom_dataset.xindexes["geom"].crs)
     )
+    fg["geom"].attrs["crs"] = CRS.from_user_input(26915)
+    return fg
 
 
 @pytest.fixture(scope="session")

--- a/xvec/tests/test_accessor.py
+++ b/xvec/tests/test_accessor.py
@@ -1,7 +1,11 @@
+import geopandas as gpd
 import numpy as np
+import pandas as pd
 import pytest
 import shapely
 import xarray as xr
+from geopandas.testing import assert_geodataframe_equal
+from pandas.testing import assert_frame_equal
 
 import xvec  # noqa
 from xvec import GeometryIndex
@@ -299,3 +303,130 @@ def test_query_array(multi_geom_dataset, unique, expected):
         "geom", [shapely.box(0, 0, 2.4, 2.2)] * 3, unique=unique
     )
     xr.testing.assert_identical(expected, actual)
+
+
+def test_to_geopandas_array(traffic_counts_array, geom_array):
+    with pytest.raises(ValueError, match="Cannot convert arrays"):
+        traffic_counts_array.xvec.to_geopandas()
+
+    with pytest.raises(ValueError, match="Multiple coordinates based on"):
+        traffic_counts_array.sel(
+            mode="car", hour=1, day="2023-01-01"
+        ).xvec.to_geopandas()
+
+    expected = pd.DataFrame(
+        {
+            "destination": geom_array,
+            0: [
+                1.0,
+                1.0,
+            ],
+            1: [
+                1.0,
+                1.0,
+            ],
+        },
+    )
+    expected.columns.name = "hour"
+    expected = expected.set_geometry("destination", crs=26915)
+
+    # transposition needed
+    actual = traffic_counts_array.sel(
+        mode="car", day="2023-01-01", origin=shapely.Point(1, 2)
+    ).xvec.to_geopandas()
+
+    assert_geodataframe_equal(expected, actual)
+
+    expected = pd.DataFrame(
+        {
+            "destination": geom_array,
+            "car": [
+                1.0,
+                1.0,
+            ],
+            "bike": [
+                1.0,
+                1.0,
+            ],
+            "walk": [
+                1.0,
+                1.0,
+            ],
+        },
+    )
+    expected.columns.name = "mode"
+    expected = expected.set_geometry("destination", crs=26915)
+    actual = traffic_counts_array.sel(
+        origin=shapely.Point(1, 2), hour=0, day="2023-01-01"
+    ).xvec.to_geopandas()
+
+    assert_geodataframe_equal(expected, actual)
+
+    # upcast Series
+    expected = pd.DataFrame(
+        {
+            "destination": geom_array,
+            0: [
+                1.0,
+                1.0,
+            ],
+        },
+    ).set_geometry("destination", crs=26915)
+
+    actual = traffic_counts_array.sel(
+        origin=shapely.Point(1, 2), hour=0, day="2023-01-01", mode="car"
+    ).xvec.to_geopandas()
+
+    assert_geodataframe_equal(expected, actual)
+
+    with pytest.warns(UserWarning, match="No geometry"):
+        traffic_counts_array.sel(
+            destination=geom_array[0],
+            origin=geom_array[0],
+            mode="car",
+            day="2023-01-01",
+        ).xvec.to_geopandas()
+
+
+def test_to_geopandas_dataset(traffic_dataset, geom_array):
+    expected = pd.DataFrame(
+        {
+            "destination": geom_array,
+            "count": [1.0, 1.0],
+            "time": [1.0, 1.0],
+            "mode": ["car", "car"],
+            "origin": [geom_array[0], geom_array[0]],
+            "hour": [0, 0],
+            "day": pd.to_datetime(["2023-01-01", "2023-01-01"]),
+        }
+    ).set_geometry("destination", crs=26915)
+    expected["origin"] = gpd.GeoSeries(expected["origin"], crs=26915)
+
+    actual = traffic_dataset.sel(
+        origin=shapely.Point(1, 2), hour=0, day="2023-01-01", mode="car"
+    ).xvec.to_geopandas()
+
+    assert_geodataframe_equal(expected, actual)
+
+    expected = traffic_dataset.sel(
+        hour=0,
+        day="2023-01-01",
+        destination=shapely.Point(3, 4),
+        origin=shapely.Point(1, 2),
+    ).to_pandas()
+    expected["origin"] = gpd.array.GeometryArray(expected["origin"].values, crs=26915)
+    expected["destination"] = gpd.array.GeometryArray(
+        expected["destination"].values, crs=26915
+    )
+
+    with pytest.warns(UserWarning, match="No active geometry column to be set"):
+        actual = traffic_dataset.sel(
+            hour=0,
+            day="2023-01-01",
+            destination=shapely.Point(3, 4),
+            origin=shapely.Point(1, 2),
+        ).xvec.to_geopandas()
+
+    assert_frame_equal(expected, actual)
+    assert actual.origin.array.crs == 26915
+    assert actual.destination.array.crs == 26915

--- a/xvec/tests/test_accessor.py
+++ b/xvec/tests/test_accessor.py
@@ -401,11 +401,11 @@ def test_to_geopandas_dataset(traffic_dataset, geom_array):
         }
     ).set_geometry("destination", crs=26915)
     expected["origin"] = gpd.GeoSeries(expected["origin"], crs=26915)
-    expected["hour"] = expected["hour"].astype("int64")
 
     actual = traffic_dataset.sel(
         origin=shapely.Point(1, 2), hour=0, day="2023-01-01", mode="car"
     ).xvec.to_geopandas()
+    actual["hour"] = actual["hour"].astype("int64")  # win fix
 
     assert_geodataframe_equal(expected, actual)
 

--- a/xvec/tests/test_accessor.py
+++ b/xvec/tests/test_accessor.py
@@ -401,6 +401,7 @@ def test_to_geopandas_dataset(traffic_dataset, geom_array):
         }
     ).set_geometry("destination", crs=26915)
     expected["origin"] = gpd.GeoSeries(expected["origin"], crs=26915)
+    expected["hour"] = expected["hour"].astype("int64")
 
     actual = traffic_dataset.sel(
         origin=shapely.Point(1, 2), hour=0, day="2023-01-01", mode="car"

--- a/xvec/tests/test_accessor.py
+++ b/xvec/tests/test_accessor.py
@@ -94,11 +94,23 @@ def test_geom_coords_indexed(multi_geom_no_index_dataset):
         ("foo", False, False),
     ],
 )
-def test_is_geom_variable(multi_geom_one_ix_foo, label, has_index, expected):
+def test_is_geom_variable(
+    multi_geom_one_ix_foo, label, has_index, expected, geom_array
+):
     assert (
         multi_geom_one_ix_foo.xvec.is_geom_variable(label, has_index=has_index)
         == expected
     )
+
+    # test array longer than 10 items
+    arr = xr.DataArray(
+        coords={
+            "geom": np.repeat(geom_array, 10),
+        },
+        dims=["geom"],
+    ).xvec.set_geom_indexes(["geom"], crs=26915)
+
+    assert arr.xvec.is_geom_variable("geom")
 
 
 # Test .xvec.to_crs

--- a/xvec/tests/test_accessor.py
+++ b/xvec/tests/test_accessor.py
@@ -455,6 +455,8 @@ def test_to_geodataframe_array(
             mode="car", hour=0, day="2023-01-01"
         ).xvec.to_geodataframe()
 
+    actual["hour"] = actual["hour"].astype("int64")  # win fix
+
     assert_frame_equal(expected, actual)
 
     expected = pd.DataFrame(
@@ -473,6 +475,8 @@ def test_to_geodataframe_array(
         mode="car", hour=0, day="2023-01-01", destination=geom_array[0]
     ).xvec.to_geodataframe()
 
+    actual["hour"] = actual["hour"].astype("int64")  # win fix
+
     assert_geodataframe_equal(expected, actual)
 
     # unnamed
@@ -482,9 +486,10 @@ def test_to_geodataframe_array(
 
     assert_geodataframe_equal(expected, actual)
 
-    reordered = traffic_counts_array_named.xvec.to_geodataframe(
-        dim_order=["day", "hour", "mode", "origin", "destination"]
-    )
+    with pytest.warns(UserWarning, match="No active geometry"):
+        reordered = traffic_counts_array_named.xvec.to_geodataframe(
+            dim_order=["day", "hour", "mode", "origin", "destination"]
+        )
     assert reordered.index.names == ["day", "hour", "mode"]
     assert (reordered.columns == ["origin", "destination", "traffic_counts"]).all()
 
@@ -503,6 +508,6 @@ def test_to_geodataframe_dataset(traffic_dataset, geom_array):
     assert actual.crs == 26915
     assert actual.origin.crs == 26915
 
-    actual = traffic_dataset.drop("origin").xvec.to_geodataframe()
+    actual = traffic_dataset.drop_vars("origin").xvec.to_geodataframe()
     assert actual.geometry.name == "destination"
     assert actual.crs == 26915

--- a/xvec/tests/test_index.py
+++ b/xvec/tests/test_index.py
@@ -28,11 +28,9 @@ def test_set_index(geom_dataset_no_index):
 
 
 def test_concat(geom_dataset, geom_array, geom_dataset_no_index, geom_dataset_no_crs):
-    expected = (
-        xr.Dataset(coords={"geom": np.concatenate([geom_array, geom_array])})
-        .drop_indexes("geom")
-        .set_xindex("geom", GeometryIndex, crs=geom_dataset.xindexes["geom"].crs)
-    )
+    expected = xr.Dataset(
+        coords={"geom": np.concatenate([geom_array, geom_array])}
+    ).xvec.set_geom_indexes("geom", crs=geom_dataset.xindexes["geom"].crs)
     actual = xr.concat([geom_dataset, geom_dataset], "geom")
     xr.testing.assert_identical(actual, expected)
 
@@ -155,6 +153,7 @@ def test_roll(geom_dataset, geom_array):
         .drop_indexes("geom")
         .set_xindex("geom", GeometryIndex, crs=geom_dataset.xindexes["geom"].crs)
     )
+    expected["geom"].attrs["crs"] = geom_dataset.xindexes["geom"].crs
     actual = geom_dataset.roll(geom=1, roll_coords=True)
     xr.testing.assert_identical(actual, expected)
 


### PR DESCRIPTION
Still WIP as tests are missing.

This adds `.xvec.to_geopandas` and `.xvec.to_geodataframe` wrapping `to_pandas` and `to_dataframe` respectively. The reason is that while converting a vector data cube to a data frame, we need 

1. preserve CRS
2. ensure that geometry array is not used as an index (in either index or columns) as GeoPandas does not support that.

To do this, I am adding one more thing and that is an inclusion of `crs` key in the attrs as there are cases when xarray returns an array of geometries that is no longer backed by GeometryIndex, so we need a fallback in that case. It also paves the way for better support of geometries as variables not just coordinates.

There are mild deviations from the xarray methods but I believe that they're justified.