### PR TITLE
Switch to ruff and sphinx-book-theme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -139,3 +139,6 @@ dmypy.json
 
 # sphinx
 doc/source/generated
+
+# ruff
+.ruff_cache

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,20 +1,14 @@
 files: 'xvec\/'
 repos:
   - repo: https://github.com/psf/black
-    rev: 22.12.0
+    rev: 23.1.0
     hooks:
       - id: black
         language_version: python3
-  - repo: https://github.com/pycqa/flake8
-    rev: 6.0.0
+  - repo: https://github.com/charliermarsh/ruff-pre-commit
+    rev: "v0.0.241"
     hooks:
-      - id: flake8
-        language: python_venv
-  - repo: https://github.com/pycqa/isort
-    rev: 5.11.4
-    hooks:
-      - id: isort
-        language_version: python3
+      - id: ruff
 
 ci:
   autofix_prs: false

--- a/doc/source/index.md
+++ b/doc/source/index.md
@@ -11,4 +11,5 @@ Xvec is in an early stage of development and we do not advise to use it yet as t
 :caption: Documentation
 quickstart.ipynb
 api.rst
+GitHub <https://github.com/martinfleis/xvec>
 ```

--- a/environment.yml
+++ b/environment.yml
@@ -16,7 +16,6 @@ dependencies:
   - myst-nb
   - sphinx-copybutton
   - numpydoc
-  - sphinx-book-theme
   - geopandas
   # linting
   - ruff
@@ -24,3 +23,4 @@ dependencies:
   - pip
   - pip:
       - sphinx_autosummary_accessors
+      - sphinx-book-theme

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,6 @@ omit = ["xvec/tests/*"]
 [tool.ruff]
 line-length = 88
 select = ["E", "F", "W", "I", "UP", "B", "A", "C4", "Q"]
-exclude = ["clustergram/test_clustergram.py", "doc"]
+exclude = ["doc"]
 target-version = "py38"
 ignore = ["B006"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,4 +50,3 @@ line-length = 88
 select = ["E", "F", "W", "I", "UP", "B", "A", "C4", "Q"]
 exclude = ["doc"]
 target-version = "py38"
-ignore = ["B006"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,3 +44,10 @@ include = [
 
 [tool.coverage.run]
 omit = ["xvec/tests/*"]
+
+[tool.ruff]
+line-length = 88
+select = ["E", "F", "W", "I", "UP", "B", "A", "C4", "Q"]
+exclude = ["clustergram/test_clustergram.py", "doc"]
+target-version = "py38"
+ignore = ["B006"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,0 @@
-[flake8]
-max_line_length = 88

--- a/xvec/accessor.py
+++ b/xvec/accessor.py
@@ -310,7 +310,6 @@ class XvecAccessor:
         transformed = {}
 
         for key, crs in variable_crs.items():
-
             if not isinstance(self._obj.xindexes[key], GeometryIndex):
                 raise ValueError(
                     f"The index '{key}' is not an xvec.GeometryIndex. "
@@ -355,7 +354,7 @@ class XvecAccessor:
 
             transformed[key] = (result, crs)
 
-        for key, (result, crs) in transformed.items():
+        for key, (result, _crs) in transformed.items():
             _obj = _obj.assign_coords({key: result})
 
         _obj = _obj.drop_indexes(variable_crs.keys())
@@ -475,7 +474,6 @@ class XvecAccessor:
             variable_crs = variable_crs_kwargs
 
         for key, crs in variable_crs.items():
-
             if not isinstance(self._obj.xindexes[key], GeometryIndex):
                 raise ValueError(
                     f"The index '{key}' is not an xvec.GeometryIndex. "

--- a/xvec/tests/test_accessor.py
+++ b/xvec/tests/test_accessor.py
@@ -55,7 +55,7 @@ def test_geom_coords(multi_geom_no_index_dataset):
 
     actual = multi_geom_no_index_dataset.xvec.geom_coords
     expected = multi_geom_no_index_dataset.coords
-    actual.keys() == expected.keys()
+    assert actual.keys() == expected.keys()
 
     # check assignment
     with pytest.raises(AttributeError):
@@ -69,7 +69,7 @@ def test_geom_coords_indexed(multi_geom_no_index_dataset):
 
     actual = multi_geom_no_index_dataset.xvec.geom_coords_indexed
     expected = multi_geom_no_index_dataset.coords
-    actual.keys() == expected.keys()
+    assert actual.keys() == expected.keys()
 
     # check assignment
     with pytest.raises(AttributeError):

--- a/xvec/tests/test_accessor.py
+++ b/xvec/tests/test_accessor.py
@@ -64,18 +64,16 @@ def test_geom_coords(multi_geom_no_index_dataset):
         )
 
 
-def test_geom_coords_indexed(multi_geom_no_index_dataset):
-    assert multi_geom_no_index_dataset.xvec._geom_indexes == ["geom", "geom_z"]
+def test_geom_coords_indexed(multi_geom_dataset):
+    assert multi_geom_dataset.xvec._geom_indexes == ["geom", "geom_z"]
 
-    actual = multi_geom_no_index_dataset.xvec.geom_coords_indexed
-    expected = multi_geom_no_index_dataset.coords
+    actual = multi_geom_dataset.xvec.geom_coords_indexed
+    expected = multi_geom_dataset.coords
     assert actual.keys() == expected.keys()
 
     # check assignment
     with pytest.raises(AttributeError):
-        multi_geom_no_index_dataset.xvec.geom_coords = (
-            multi_geom_no_index_dataset.coords
-        )
+        multi_geom_dataset.xvec.geom_coords = multi_geom_dataset.coords
 
 
 # Test .xvec.is_geom_variable


### PR DESCRIPTION
Minor infrastructural work.

Switching to ruff for linting and sphinx-book-theme for docs. Former allows us to get rid of setup.cfg and latter is better suited as pydata theme is a bit overkill.

Will merge myself when green.