### PR TITLE
BUG: geom_coords and geom_coords_indexed for array

### DIFF
--- a/xvec/accessor.py
+++ b/xvec/accessor.py
@@ -139,8 +139,10 @@ class XvecAccessor:
         geom_coords_indexed
         is_geom_variable
         """
-        return self._obj.drop_vars(
-            [c for c in self._obj.coords if c not in self._geom_coords_all]
+        # TODO: use xarray.Coordinates constructor instead once available in xarray
+        return xr.DataArray(
+            coords={c: self._obj[c] for c in self._geom_coords_all},
+            dims=self._geom_coords_all,
         ).coords
 
     @property
@@ -188,6 +190,7 @@ class XvecAccessor:
         is_geom_variable
 
         """
+        # TODO: use xarray.Coordinates constructor instead once available in xarray
         return self._obj.drop_vars(
             [c for c in self._obj.coords if c not in self._geom_indexes]
         ).coords

--- a/xvec/accessor.py
+++ b/xvec/accessor.py
@@ -127,6 +127,7 @@ class XvecAccessor:
         Indexes:
             geom           GeometryIndex (crs=EPSG:26915)
             geom_z         GeometryIndex (crs=EPSG:26915)
+
         >>> ds.xvec.geom_coords
         Coordinates:
           * geom           (geom) object POINT (1 2) POINT (3 4)
@@ -138,7 +139,9 @@ class XvecAccessor:
         geom_coords_indexed
         is_geom_variable
         """
-        return self._obj[self._geom_coords_all].coords
+        return self._obj.drop_vars(
+            [c for c in self._obj.coords if c not in self._geom_coords_all]
+        ).coords
 
     @property
     def geom_coords_indexed(self) -> Mapping[Hashable, xr.DataArray]:
@@ -173,7 +176,7 @@ class XvecAccessor:
         Indexes:
             geom           GeometryIndex (crs=EPSG:26915)
             geom_z         GeometryIndex (crs=EPSG:26915)
-        >>> ds.xvec.geom_coords_indexed
+
         >>> ds.xvec.geom_coords_indexed
         Coordinates:
           * geom     (geom) object POINT (1 2) POINT (3 4)
@@ -185,7 +188,9 @@ class XvecAccessor:
         is_geom_variable
 
         """
-        return self._obj[self._geom_indexes].coords
+        return self._obj.drop_vars(
+            [c for c in self._obj.coords if c not in self._geom_indexes]
+        ).coords
 
     def to_crs(
         self,

--- a/xvec/tests/conftest.py
+++ b/xvec/tests/conftest.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pandas as pd
 import pytest
 import shapely
 import xarray as xr
@@ -106,3 +107,16 @@ def multi_geom_one_ix_foo(geom_array):
         .drop_indexes(["geom"])
         .set_xindex("geom", GeometryIndex, crs=26915)
     )
+
+
+@pytest.fixture(scope="session")
+def traffic_counts_array(geom_array):
+    return xr.DataArray(
+        np.ones((3, 10, 2, 2)),
+        coords={
+            "mode": ["car", "bike", "walk"],
+            "day": pd.date_range("2023-01-01", periods=10),
+            "origin": geom_array,
+            "destination": geom_array,
+        },
+    ).xvec.set_geom_indexes(["origin", "destination"], crs=26915)

--- a/xvec/tests/test_accessor.py
+++ b/xvec/tests/test_accessor.py
@@ -46,7 +46,7 @@ def test_accessor(multi_geom_dataset):
 # Test .xvec geom_coords
 
 
-def test_geom_coords(multi_geom_no_index_dataset):
+def test_geom_coords(multi_geom_no_index_dataset, traffic_counts_array, geom_array):
     assert multi_geom_no_index_dataset.xvec._geom_coords_all == [
         "geom",
         "geom_z",
@@ -63,8 +63,15 @@ def test_geom_coords(multi_geom_no_index_dataset):
             multi_geom_no_index_dataset.coords
         )
 
+    actual = traffic_counts_array.xvec.geom_coords
+    expected = xr.DataArray(
+        coords={"origin": geom_array, "destination": geom_array},
+        dims=("origin", "destination"),
+    ).coords
+    assert actual.keys() == expected.keys()
 
-def test_geom_coords_indexed(multi_geom_dataset):
+
+def test_geom_coords_indexed(multi_geom_dataset, traffic_counts_array, geom_array):
     assert multi_geom_dataset.xvec._geom_indexes == ["geom", "geom_z"]
 
     actual = multi_geom_dataset.xvec.geom_coords_indexed
@@ -74,6 +81,13 @@ def test_geom_coords_indexed(multi_geom_dataset):
     # check assignment
     with pytest.raises(AttributeError):
         multi_geom_dataset.xvec.geom_coords = multi_geom_dataset.coords
+
+    actual = traffic_counts_array.xvec.geom_coords
+    expected = xr.DataArray(
+        coords={"origin": geom_array, "destination": geom_array},
+        dims=("origin", "destination"),
+    ).coords
+    assert actual.keys() == expected.keys()
 
 
 # Test .xvec.is_geom_variable


### PR DESCRIPTION
This fixes #21 but I am not sure if the solution is optimal. As far as I can tell, there's no way to return a subset of `da.coords`. I am afraid that this will do an unnecessary copy of the data. If that is the case and there's no easy no-copy way of returning a subset of `xarray.core.coordinates.DataArrayCoordinates`, it may be better to return just a simple list.

Other option would be to create a new DataArray from the subset of coords and return coords of that but I am again not sure if this would not mess with copy/view.

```py
return xr.DataArray(
    coords={c: self._obj[c] for c in self._geom_coords_all},
    dims=self._geom_coords_all,
).coords
```

@benbovy do you have a bit more insight into xarray internals to have a sense what is the best here?
